### PR TITLE
fix crash

### DIFF
--- a/coverart.lua
+++ b/coverart.lua
@@ -362,11 +362,11 @@ function main(workingDirectory, filepath, exact_path, directory)
     if o.load_from_filesystem then
         --loads the files from the directory
         succeeded = addFromDirectory(directory)
-        if not o.load_extra_files and succeeded > 0 then return end
+        if not o.load_extra_files and succeeded or 0 > 0 then return end
 
         if o.check_parent and succeeded then
             succeeded = addFromDirectory(directory .. "/../")
-            if not o.load_extra_files and succeeded > 0 then return end
+            if not o.load_extra_files and succeeded or 0 > 0 then return end
         end
     end
     if ((not succeeded) and o.auto_load_from_playlist) or o.load_from_playlist then


### PR DESCRIPTION
Had this happen on an icecast stream
```
[coverart] 
[coverart] stack traceback:                                                                                                                                                                                       
[coverart]      [string "/home/eva/.config/mpv/scripts/coverart.lua"]:348: in function 'main'
[coverart]      [string "/home/eva/.config/mpv/scripts/coverart.lua"]:337: in function 'fn'
[coverart]      mp.defaults:574: in function 'handler'
[coverart]      mp.defaults:495: in function 'call_event_handlers'
[coverart]      mp.defaults:529: in function 'dispatch_events'
[coverart]      mp.defaults:488: in function <mp.defaults:487>
[coverart]      [C]: in ?
[coverart]      [C]: in ?
[coverart] Lua error: [string "/home/eva/.config/mpv/scripts/coverart.lua"]:348: attempt to compare number with boolean
client removed during hook handling
```

`if not o.load_extra_files and succeeded > 0 then return end`
`succeeded` is assigned to `addFromDirectory(directory)` but that function can return `false`.