### PR TITLE
add any_image_fallback option

### DIFF
--- a/coverart.conf
+++ b/coverart.conf
@@ -82,3 +82,6 @@ use_albumart_flag=no
 #this setting forces the first embedded file to be played instead
 #to be specific this option just sets --vid to 1 when it is on auto
 prefer_embedded=no
+
+#fallback to the first image with matching extension if none of names option were found
+any_image_fallback=no


### PR DESCRIPTION
Now almost exactly 3 years later, I forgot my fork existed and ended up implementing it in a much nicer way.  
Closes #1

Changes `isValidCoverart` to return `nil` for an extension whitelist fail, it doesn't break existing conditions and doesn't introduce extra burden as it's still falsy.  
We keep track of the first extension-valid file (which returned `false`) in directory/playlist, and use it if nothing else matched.  
Placeholder picture still works if no matching extensions are found.